### PR TITLE
Add -c flag to count the track number in a 3digit wide playlist order

### DIFF
--- a/spotrec.py
+++ b/spotrec.py
@@ -189,7 +189,9 @@ class Spotify:
     playbackstatus_paused = "Paused"
 
     def __init__(self):
-        self.glibloop = dbus.mainloop.glib.DBusGMainLoop(set_as_default=True)
+        self.glibloop = None
+        
+        dbus.mainloop.glib.DBusGMainLoop(set_as_default=True)
 
         try:
             bus = dbus.SessionBus()

--- a/spotrec.py
+++ b/spotrec.py
@@ -144,7 +144,7 @@ def handle_command_line():
                         action="store_true", default=not _tmp_file)
     parser.add_argument("-u", "--underscored-filenames", help="Force the file names to have underscores instead of whitespaces",
                         action="store_true", default=_underscored_filenames)
-    parser.add_argument("-c", "--pl-track-counter", help="Output filename gets the track number of playlist order", action="store_true", default=_use_pl_track_counter)
+    parser.add_argument("-c", "--pl-track-counter", help="Replace Spotify's tracknumber with own counter. Useable for preserving a playlist file order.", action="store_true", default=_use_pl_track_counter)
 
     args = parser.parse_args()
 
@@ -389,7 +389,7 @@ class Spotify:
 
     def update_metadata(self):
         global pl_track_counter
-        
+
         self.metadata = self.iface.Get(self.mpris_player_string, "Metadata")
 
         self.metadata_artist = ", ".join(

--- a/spotrec.py
+++ b/spotrec.py
@@ -39,7 +39,7 @@ _output_directory = f"{Path.home()}/{app_name}"
 _filename_pattern = "{trackNumber} - {artist} - {title}"
 _tmp_file = True
 _underscored_filenames = False
-_use_intern_track_counter = False
+_use_internal_track_counter = False
 
 # Hard-coded settings
 _pa_recording_sink_name = "spotrec"
@@ -55,7 +55,7 @@ _ffmpeg_executable = "ffmpeg"  # Example: "/usr/bin/ffmpeg"
 is_script_paused = False
 is_first_playing = True
 pa_spotify_sink_input_id = -1
-intern_track_counter = 1
+internal_track_counter = 1
 
 
 def main():
@@ -124,7 +124,7 @@ def handle_command_line():
     global _filename_pattern
     global _tmp_file
     global _underscored_filenames
-    global _use_intern_track_counter
+    global _use_internal_track_counter
 
     #parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
     parser = argparse.ArgumentParser(
@@ -144,7 +144,7 @@ def handle_command_line():
                         action="store_true", default=not _tmp_file)
     parser.add_argument("-u", "--underscored-filenames", help="Force the file names to have underscores instead of whitespaces",
                         action="store_true", default=_underscored_filenames)
-    parser.add_argument("-c", "--intern-track-counter", help="Replace Spotify's tracknumber with own counter. Useable for preserving a playlist file order.", action="store_true", default=_use_intern_track_counter)
+    parser.add_argument("-c", "--internal-track-counter", help="Replace Spotify's tracknumber with own counter. Useable for preserving a playlist file order.", action="store_true", default=_use_internal_track_counter)
 
     args = parser.parse_args()
 
@@ -162,7 +162,7 @@ def handle_command_line():
 
     _underscored_filenames = args.underscored_filenames
 
-    _use_intern_track_counter = args.intern_track_counter
+    _use_internal_track_counter = args.internal_track_counter
 
 def init_log():
     global log
@@ -388,7 +388,7 @@ class Spotify:
         self.init_pa_stuff_if_needed()
 
     def update_metadata(self):
-        global intern_track_counter
+        global internal_track_counter
 
         self.metadata = self.iface.Get(self.mpris_player_string, "Metadata")
 
@@ -398,8 +398,8 @@ class Spotify:
         self.metadata_title = self.metadata.get(dbus.String(u'xesam:title'))
         self.metadata_trackNumber = str(self.metadata.get(
             dbus.String(u'xesam:trackNumber'))).zfill(2)
-        if _use_intern_track_counter:
-            self.metadata_trackNumber = str(intern_track_counter).zfill(3)           
+        if _use_internal_track_counter:
+            self.metadata_trackNumber = str(internal_track_counter).zfill(3)           
 
 
     def init_pa_stuff_if_needed(self):
@@ -455,7 +455,7 @@ class FFmpeg:
 
     # The blocking version of this method waits until the process is dead
     def stop_blocking(self):
-        global intern_track_counter
+        global internal_track_counter
 
         # Remove from instances list (and terminate)
         if self in self.instances:
@@ -492,8 +492,8 @@ class FFmpeg:
             self.process = None
 
             # Update playlist counter here to get rid of too many triggers for counting
-            if _use_intern_track_counter:
-                intern_track_counter += 1
+            if _use_internal_track_counter:
+                internal_track_counter += 1
 
     # Kill the process in the background
     def stop(self):

--- a/spotrec.py
+++ b/spotrec.py
@@ -39,7 +39,7 @@ _output_directory = f"{Path.home()}/{app_name}"
 _filename_pattern = "{trackNumber} - {artist} - {title}"
 _tmp_file = True
 _underscored_filenames = False
-_use_pl_track_counter = False
+_use_intern_track_counter = False
 
 # Hard-coded settings
 _pa_recording_sink_name = "spotrec"
@@ -55,7 +55,7 @@ _ffmpeg_executable = "ffmpeg"  # Example: "/usr/bin/ffmpeg"
 is_script_paused = False
 is_first_playing = True
 pa_spotify_sink_input_id = -1
-pl_track_counter = 1
+intern_track_counter = 1
 
 
 def main():
@@ -124,7 +124,7 @@ def handle_command_line():
     global _filename_pattern
     global _tmp_file
     global _underscored_filenames
-    global _use_pl_track_counter
+    global _use_intern_track_counter
 
     #parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
     parser = argparse.ArgumentParser(
@@ -144,7 +144,7 @@ def handle_command_line():
                         action="store_true", default=not _tmp_file)
     parser.add_argument("-u", "--underscored-filenames", help="Force the file names to have underscores instead of whitespaces",
                         action="store_true", default=_underscored_filenames)
-    parser.add_argument("-c", "--pl-track-counter", help="Replace Spotify's tracknumber with own counter. Useable for preserving a playlist file order.", action="store_true", default=_use_pl_track_counter)
+    parser.add_argument("-c", "--intern-track-counter", help="Replace Spotify's tracknumber with own counter. Useable for preserving a playlist file order.", action="store_true", default=_use_intern_track_counter)
 
     args = parser.parse_args()
 
@@ -162,7 +162,7 @@ def handle_command_line():
 
     _underscored_filenames = args.underscored_filenames
 
-    _use_pl_track_counter = args.pl_track_counter
+    _use_intern_track_counter = args.intern_track_counter
 
 def init_log():
     global log
@@ -388,7 +388,7 @@ class Spotify:
         self.init_pa_stuff_if_needed()
 
     def update_metadata(self):
-        global pl_track_counter
+        global intern_track_counter
 
         self.metadata = self.iface.Get(self.mpris_player_string, "Metadata")
 
@@ -398,8 +398,8 @@ class Spotify:
         self.metadata_title = self.metadata.get(dbus.String(u'xesam:title'))
         self.metadata_trackNumber = str(self.metadata.get(
             dbus.String(u'xesam:trackNumber'))).zfill(2)
-        if _use_pl_track_counter:
-            self.metadata_trackNumber = str(pl_track_counter).zfill(3)           
+        if _use_intern_track_counter:
+            self.metadata_trackNumber = str(intern_track_counter).zfill(3)           
 
 
     def init_pa_stuff_if_needed(self):
@@ -455,7 +455,7 @@ class FFmpeg:
 
     # The blocking version of this method waits until the process is dead
     def stop_blocking(self):
-        global pl_track_counter
+        global intern_track_counter
 
         # Remove from instances list (and terminate)
         if self in self.instances:
@@ -492,8 +492,8 @@ class FFmpeg:
             self.process = None
 
             # Update playlist counter here to get rid of too many triggers for counting
-            if _use_pl_track_counter:
-                pl_track_counter += 1
+            if _use_intern_track_counter:
+                intern_track_counter += 1
 
     # Kill the process in the background
     def stop(self):

--- a/spotrec.py
+++ b/spotrec.py
@@ -39,7 +39,7 @@ _output_directory = f"{Path.home()}/{app_name}"
 _filename_pattern = "{trackNumber} - {artist} - {title}"
 _tmp_file = True
 _underscored_filenames = False
-_sort_in_folders = False
+_use_pl_track_counter = False
 
 # Hard-coded settings
 _pa_recording_sink_name = "spotrec"
@@ -50,6 +50,7 @@ _playback_time_before_seeking_to_beginning = 4.5
 _shell_executable = "/bin/bash"  # Default: "/bin/sh"
 _shell_encoding = "utf-8"
 _ffmpeg_executable = "ffmpeg"  # Example: "/usr/bin/ffmpeg"
+_pl_track_counter = 1
 
 # Variables that change during runtime
 is_script_paused = False
@@ -123,7 +124,7 @@ def handle_command_line():
     global _filename_pattern
     global _tmp_file
     global _underscored_filenames
-    global _sort_in_folders
+    global _use_pl_track_counter
 
     #parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
     parser = argparse.ArgumentParser(
@@ -143,7 +144,7 @@ def handle_command_line():
                         action="store_true", default=not _tmp_file)
     parser.add_argument("-u", "--underscored-filenames", help="Force the file names to have underscores instead of whitespaces",
                         action="store_true", default=_underscored_filenames)
-    parser.add_argument("-a", "--sort-in-folders", help="Sort the files into album folders", action="store_true", default=_sort_in_folders)
+    parser.add_argument("-c", "--pl-track-counter", help="Output filename gets the track number of playlist order", action="store_true", default=_use_pl_track_counter)
 
     args = parser.parse_args()
 
@@ -161,7 +162,7 @@ def handle_command_line():
 
     _underscored_filenames = args.underscored_filenames
 
-    _sort_folder = args.sort_in_folders
+    _use_pl_track_counter = args.pl_track_counter
 
 def init_log():
     global log
@@ -188,7 +189,7 @@ class Spotify:
     playbackstatus_paused = "Paused"
 
     def __init__(self):
-        dbus.mainloop.glib.DBusGMainLoop(set_as_default=True)
+        self.glibloop = dbus.mainloop.glib.DBusGMainLoop(set_as_default=True)
 
         try:
             bus = dbus.SessionBus()
@@ -228,7 +229,7 @@ class Spotify:
 
         log.info(f"[{app_name}] Spotify DBus listener started")
 
-        log.info(f"[{app_name}] Current song: " + self.track + " from the album |" + self.metadata_album + "|")
+        log.info(f"[{app_name}] Current song: " + self.track + " from the album " + self.metadata_album)
         log.info(f"[{app_name}] Current state: " + self.playbackstatus)
 
     # TODO: this is a dirty solution (uses cmdline instead of python for now)
@@ -254,7 +255,7 @@ class Spotify:
             filename_pattern = re.sub(" - ", "__", _filename_pattern)
         else:
             filename_pattern = _filename_pattern
-
+        
         ret = str(filename_pattern.format(
             artist=self.metadata_artist,
             album=self.metadata_album,
@@ -351,10 +352,14 @@ class Spotify:
 
     # This gets called whenever Spotify sends the playingUriChanged signal
     def on_playing_uri_changed(self, Player, three, four):
+        global _pl_track_counter
         #log.debug("uri changed event")
 
         # Update Metadata
         self.update_metadata()
+
+        if _use_pl_track_counter:
+            _pl_track_counter += 1
 
         # Update track & trackid
 
@@ -392,9 +397,12 @@ class Spotify:
         self.metadata_artist = ", ".join(
             self.metadata.get(dbus.String(u'xesam:artist')))
         self.metadata_album = self.metadata.get(dbus.String(u'xesam:album'))
+        self.metadata_title = self.metadata.get(dbus.String(u'xesam:title'))
         self.metadata_trackNumber = str(self.metadata.get(
             dbus.String(u'xesam:trackNumber'))).zfill(2)
-        self.metadata_title = self.metadata.get(dbus.String(u'xesam:title'))
+        if _use_pl_track_counter:
+            self.metadata_trackNumber = str(_pl_track_counter).zfill(3)           
+
 
     def init_pa_stuff_if_needed(self):
         if self.is_playing():
@@ -413,37 +421,33 @@ class FFmpeg:
     instances = []
 
     def record(self, filename, metadata_for_file={}):
+        global _output_directory
+
         self.pulse_input = _pa_recording_sink_name + ".monitor"
 
         if _tmp_file:
             # Use a dot as filename prefix to hide the file until the recording was successful
             self.tmp_file_prefix = "."
-            self.filename = self.tmp_file_prefix + filename + ".flac"
+            self.filename = self.tmp_file_prefix + os.path.basename(filename) + ".flac"
         else:
-            self.filename = filename + ".flac"
-        # Fix for filenames containing '/'
-        self.filename = self.filename.replace("/", "_")
+            self.filename = os.path.basename(filename) + ".flac"
 
         # build metadata param
         metadata_params = ''
         for key, value in metadata_for_file.items():
             metadata_params += ' -metadata ' + key + '=' + shlex.quote(value)
 
-        # if sorting in folders is turned on the output directory name changes
-        if _sort_in_folders:
-            self.outputDir = os.path.join(_output_directory, metadata_for_file["artist"] + " - " + metadata_for_file["album"])
-        else:
-            self.outputDir = _output_directory
-
-        # If output folder is not available create it
-        if not os.path.isdir(self.outputDir):
-            os.mkdir(self.outputDir)
+        # If output folder is not available then create it
+        # If filename_pattern specifies a subfolder path the track name is only the basename the rest is a subfolder path
+        self.outsubdir = os.path.dirname(filename)
+        Path(os.path.join(_output_directory, self.outsubdir)).mkdir(parents=True, exist_ok=True)
 
         # FFmpeg Options:
         #  "-hide_banner": to short the debug log a little
         #  "-y": to overwrite existing files
         self.process = Shell.Popen(_ffmpeg_executable + ' -hide_banner -y -f pulse -ac 2 -ar 44100 -i ' +
-		                   self.pulse_input + metadata_params + ' -acodec flac ' + shlex.quote(os.path.join(self.outputDir, self.filename)))
+		                   self.pulse_input + metadata_params + ' -acodec flac ' + 
+                                   shlex.quote(os.path.join(_output_directory, self.outsubdir, self.filename)))
 
         self.pid = str(self.process.pid)
 
@@ -473,8 +477,8 @@ class FFmpeg:
                 log.info(f"[FFmpeg] [{self.pid}] killed")
             else:
                 if _tmp_file:
-                    tmp_file = os.path.join(self.outputDir, self.filename)
-                    new_file = os.path.join(self.outputDir,
+                    tmp_file = os.path.join(_output_directory, self.outsubdir, self.filename)
+                    new_file = os.path.join(_output_directory, self.outsubdir, 
                                             self.filename[len(self.tmp_file_prefix):])
                     if os.path.exists(tmp_file):
                         shutil.move(tmp_file, new_file)


### PR DESCRIPTION
Wanted to have the following features:
-   The files shall be sorted into folders like \<artist\> - \<album\>
-   The files shall have a file name prefix (e.g. 012_*) that counts up per playlist track. 
    This way the files are stored in the same order on disk as they are in the playlist.
