### PR TITLE
Handle slashes in filenames correctly

### DIFF
--- a/spotrec.py
+++ b/spotrec.py
@@ -268,10 +268,10 @@ class Spotify:
             filename_pattern = _filename_pattern
 
         ret = str(filename_pattern.format(
-            artist=self.metadata_artist,
-            album=self.metadata_album,
+            artist=self.metadata_artist.replace("/","_"),
+            album=self.metadata_album.replace("/","_"),
             trackNumber=self.metadata_trackNumber,
-            title=self.metadata_title
+            title=self.metadata_title.replace("/","_")
         ))
 
         if _underscored_filenames:


### PR DESCRIPTION
Since the file pattern may contain slashes, the `replace` is applied
to metadata members individually (as opposed to applying to the overall
file name).